### PR TITLE
ci: ephemeral PR preview deploys + production-only main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,14 @@
 name: Deploy
 
-# Push to main -> production Worker `dbtlr-com` (serves dbtlr.com once the custom domain is attached).
-# Push to v2   -> staging Worker `dbtlr-com-v2` on workers.dev.
+# Push to main -> production Worker `dbtlr-com` (serves dbtlr.com).
+# PR previews live in preview.yml.
 on:
   push:
-    branches: [main, v2]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: deploy-${{ github.ref_name }}
+  group: deploy-main
   cancel-in-progress: true
 
 jobs:
@@ -28,4 +28,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: ${{ github.ref_name == 'main' && 'deploy' || 'deploy --name dbtlr-com-v2' }}
+          command: deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,61 @@
+name: PR Preview
+
+# Every PR to main gets an ephemeral preview: `wrangler versions upload` uploads a
+# new version of the `dbtlr-com` Worker WITHOUT deploying it to production, and we
+# post its preview URL on the PR. Production is untouched until the PR merges.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm build
+      - id: preview
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: versions upload
+      - name: Comment preview URL
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const url = `${{ steps.preview.outputs.deployment-url }}`;
+            const marker = '<!-- pr-preview -->';
+            const body = [
+              marker,
+              '### 🔎 Preview deploy',
+              '',
+              url ? url : '_No preview URL produced — check the workflow logs._',
+              '',
+              `<sub>Updated for ${context.sha.slice(0, 7)} · ephemeral version, not production.</sub>`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }


### PR DESCRIPTION
Sets up the new workflow: feature branch → PR → merge to main.

- **preview.yml** — every PR uploads an ephemeral preview version of the `dbtlr-com` Worker (`wrangler versions upload`, production untouched) and comments the preview URL.
- **deploy.yml** — simplified to deploy production on push to `main` only.

This PR is also the first test of the preview flow — watch for the preview comment below.