### PR TITLE
[codex] Skip private writing paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ slug: optional-manual-slug
 ```
 
 Only `status: published` files are synced; drafts, stubs, and missing statuses are
-skipped. The sync command writes generated Markdown to `src/content/writing/` and
+skipped. Files and directories whose names start with `_` are ignored entirely, so
+vault-side templates, notes, and publishing process folders can live beside article
+sources. The sync command writes generated Markdown to `src/content/writing/` and
 tracks stable source-to-slug mappings in `src/content/writing/.sync-manifest.json`.
 
 ```sh

--- a/scripts/sync-writing.ts
+++ b/scripts/sync-writing.ts
@@ -367,6 +367,9 @@ async function listMarkdownFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
     entries.map(async (entry) => {
+      if (entry.name.startsWith('_')) {
+        return [];
+      }
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         return listMarkdownFiles(fullPath);


### PR DESCRIPTION
## Summary

Updates the writing sync process so underscore-prefixed source files and directories are treated as private authoring/process space.

## What changed

- `scripts/sync-writing.ts` now skips any directory entry whose basename starts with `_` during traversal.
- README documents that `_templates/`, `_meta.md`, and similar vault-side publishing/process paths are ignored entirely.

## Why

This lets the local writing source folder contain templates, metadata, notes, and publishing process scaffolding beside article drafts without the sync script parsing or reporting them.

## Validation

- Fixture sync test where `_meta.md` and `_templates/template.md` looked publishable but were ignored, while `articles/real-post.md` synced.
- `pnpm sync:writing -- --dry-run`
- `pnpm exec tsc --ignoreConfig --noEmit --module NodeNext --moduleResolution NodeNext --target ES2024 --types node --esModuleInterop scripts/sync-writing.ts`
- `pnpm check`
- `pnpm build`

`pnpm check` and `pnpm build` still show the known empty-writing collection warning until the first article exists.