### PR TITLE
chore: migrate Saga binding to Atlas Skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.saga.toml
+.atlas.toml
 .env
 node_modules/
 dist/


### PR DESCRIPTION
Renames the local Saga binding `.saga.toml` → `.atlas.toml` (workspace-only; the vault is always the atlas vault at $ATLAS_PATH). The binding file is gitignored, so the only tracked change is the `.gitignore` entry.

Part of the Saga → Atlas Skills migration. Sibling repos `periodic` and `skald` took the same change directly on main; dbtlr.com requires a PR.

_Website content still describes the `saga` product — that's a separate rename, intentionally not touched here._